### PR TITLE
Default mapping for knative_revision & autodetect labels (#252)

### DIFF
--- a/monitoredresource/aws/aws_identity_doc_utils.go
+++ b/monitoredresource/aws/aws_identity_doc_utils.go
@@ -1,4 +1,4 @@
-// Copyright 2018, OpenCensus Authors
+// Copyright 2020, OpenCensus Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package monitoredresource
+package aws
 
 import (
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"

--- a/monitoredresource/aws/monitored_resources.go
+++ b/monitoredresource/aws/monitored_resources.go
@@ -1,0 +1,97 @@
+// Copyright 2020, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aws
+
+import (
+	"fmt"
+	"sync"
+)
+
+// Interface is a type that represent monitor resource that satisfies monitoredresource.Interface
+type Interface interface {
+
+	// MonitoredResource returns the resource type and resource labels.
+	MonitoredResource() (resType string, labels map[string]string)
+}
+
+// EC2Instance represents aws_ec2_instance type monitored resource.
+// For definition refer to
+// https://cloud.google.com/monitoring/api/resources#tag_aws_ec2_instance
+type EC2Instance struct {
+
+	// AWSAccount is the AWS account number for the VM.
+	AWSAccount string
+
+	// InstanceID is the instance id of the instance.
+	InstanceID string
+
+	// Region is the AWS region for the VM. The format of this field is "aws:{region}",
+	// where supported values for {region} are listed at
+	// http://docs.aws.amazon.com/general/latest/gr/rande.html.
+	Region string
+}
+
+// MonitoredResource returns resource type and resource labels for AWSEC2Instance
+func (aws *EC2Instance) MonitoredResource() (resType string, labels map[string]string) {
+	labels = map[string]string{
+		"aws_account": aws.AWSAccount,
+		"instance_id": aws.InstanceID,
+		"region":      aws.Region,
+	}
+	return "aws_ec2_instance", labels
+}
+
+// Autodetect auto detects monitored resources based on
+// the environment where the application is running.
+// It supports detection of following resource types
+// 1. aws_ec2_instance:
+//
+// Returns MonitoredResInterface which implements getLabels() and getType()
+// For resource definition go to https://cloud.google.com/monitoring/api/resources
+func Autodetect() Interface {
+	return func() Interface {
+		detectOnce.Do(func() {
+			autoDetected = detectResourceType(retrieveAWSIdentityDocument())
+		})
+		return autoDetected
+	}()
+
+}
+
+// createAWSEC2InstanceMonitoredResource creates a aws_ec2_instance monitored resource
+// awsIdentityDoc contains AWS EC2 specific attributes.
+func createEC2InstanceMonitoredResource(awsIdentityDoc *awsIdentityDocument) *EC2Instance {
+	awsInstance := EC2Instance{
+		AWSAccount: awsIdentityDoc.accountID,
+		InstanceID: awsIdentityDoc.instanceID,
+		Region:     fmt.Sprintf("aws:%s", awsIdentityDoc.region),
+	}
+	return &awsInstance
+}
+
+// detectOnce is used to make sure AWS metadata detect function executes only once.
+var detectOnce sync.Once
+
+// autoDetected is the metadata detected after the first execution of Autodetect function.
+var autoDetected Interface
+
+// detectResourceType determines the resource type.
+// awsIdentityDoc contains AWS EC2 attributes. nil if it is not AWS EC2 environment
+func detectResourceType(awsIdentityDoc *awsIdentityDocument) Interface {
+	if awsIdentityDoc != nil {
+		return createEC2InstanceMonitoredResource(awsIdentityDoc)
+	}
+	return nil
+}

--- a/monitoredresource/aws/monitored_resources_test.go
+++ b/monitoredresource/aws/monitored_resources_test.go
@@ -1,0 +1,39 @@
+// Copyright 2020, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aws
+
+import (
+	"testing"
+)
+
+func TestAWSEC2InstanceMonitoredResources(t *testing.T) {
+	awsIdentityDoc := &awsIdentityDocument{
+		"123456789012",
+		"i-1234567890abcdef0",
+		"us-west-2",
+	}
+	autoDetected := detectResourceType(awsIdentityDoc)
+
+	if autoDetected == nil {
+		t.Fatal("AWSEC2InstanceMonitoredResource nil")
+	}
+	resType, labels := autoDetected.MonitoredResource()
+	if resType != "aws_ec2_instance" ||
+		labels["instance_id"] != "i-1234567890abcdef0" ||
+		labels["aws_account"] != "123456789012" ||
+		labels["region"] != "aws:us-west-2" {
+		t.Errorf("AWSEC2InstanceMonitoredResource Failed: %v", autoDetected)
+	}
+}

--- a/monitoredresource/deprecated.go
+++ b/monitoredresource/deprecated.go
@@ -1,0 +1,101 @@
+// Copyright 2020, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package monitoredresource
+
+import (
+	"contrib.go.opencensus.io/exporter/stackdriver/monitoredresource/aws"
+	"contrib.go.opencensus.io/exporter/stackdriver/monitoredresource/gcp"
+)
+
+// GKEContainer represents gke_container type monitored resource.
+// For definition refer to
+// https://cloud.google.com/monitoring/api/resources#tag_gke_container
+// Deprecated: please use gcp.GKEContainer from "contrib.go.opencensus.io/exporter/stackdriver/monitoredresource/gcp".
+type GKEContainer struct {
+	// ProjectID is the identifier of the GCP project associated with this resource, such as "my-project".
+	ProjectID string
+
+	// InstanceID is the numeric VM instance identifier assigned by Compute Engine.
+	InstanceID string
+
+	// ClusterName is the name for the cluster the container is running in.
+	ClusterName string
+
+	// ContainerName is the name of the container.
+	ContainerName string
+
+	// NamespaceID is the identifier for the cluster namespace the container is running in
+	NamespaceID string
+
+	// PodID is the identifier for the pod the container is running in.
+	PodID string
+
+	// Zone is the Compute Engine zone in which the VM is running.
+	Zone string
+
+	// LoggingMonitoringV2Enabled is the identifier if user enabled V2 logging and monitoring for GKE
+	LoggingMonitoringV2Enabled bool
+}
+
+// MonitoredResource returns resource type and resource labels for GKEContainer
+func (gke *GKEContainer) MonitoredResource() (resType string, labels map[string]string) {
+	gcpGKE := gcp.GKEContainer(*gke)
+	return gcpGKE.MonitoredResource()
+}
+
+// GCEInstance represents gce_instance type monitored resource.
+// For definition refer to
+// https://cloud.google.com/monitoring/api/resources#tag_gce_instance
+// Deprecated: please use gcp.GCEInstance from "contrib.go.opencensus.io/exporter/stackdriver/monitoredresource/gcp".
+type GCEInstance struct {
+
+	// ProjectID is the identifier of the GCP project associated with this resource, such as "my-project".
+	ProjectID string
+
+	// InstanceID is the numeric VM instance identifier assigned by Compute Engine.
+	InstanceID string
+
+	// Zone is the Compute Engine zone in which the VM is running.
+	Zone string
+}
+
+// MonitoredResource returns resource type and resource labels for GCEInstance
+func (gce *GCEInstance) MonitoredResource() (resType string, labels map[string]string) {
+	gcpGCE := gcp.GCEInstance(*gce)
+	return gcpGCE.MonitoredResource()
+}
+
+// AWSEC2Instance represents aws_ec2_instance type monitored resource.
+// For definition refer to
+// https://cloud.google.com/monitoring/api/resources#tag_aws_ec2_instance
+// Deprecated: please use aws.EC2Container from "contrib.go.opencensus.io/exporter/stackdriver/monitoredresource/aws".
+type AWSEC2Instance struct {
+	// AWSAccount is the AWS account number for the VM.
+	AWSAccount string
+
+	// InstanceID is the instance id of the instance.
+	InstanceID string
+
+	// Region is the AWS region for the VM. The format of this field is "aws:{region}",
+	// where supported values for {region} are listed at
+	// http://docs.aws.amazon.com/general/latest/gr/rande.html.
+	Region string
+}
+
+// MonitoredResource returns resource type and resource labels for AWSEC2Instance
+func (ec2 *AWSEC2Instance) MonitoredResource() (resType string, labels map[string]string) {
+	awsEC2 := aws.EC2Instance(*ec2)
+	return awsEC2.MonitoredResource()
+}

--- a/monitoredresource/deprecated_test.go
+++ b/monitoredresource/deprecated_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018, OpenCensus Authors
+// Copyright 2020, OpenCensus Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -31,20 +31,16 @@ const (
 
 func TestGKEContainerMonitoredResources(t *testing.T) {
 	os.Setenv("KUBERNETES_SERVICE_HOST", "127.0.0.1")
-	gcpMetadata := gcpMetadata{
-		instanceID:    GCPInstanceIDStr,
-		projectID:     GCPProjectIDStr,
-		zone:          GCPZoneStr,
-		clusterName:   GKEClusterNameStr,
-		containerName: GKEContainerNameStr,
-		namespaceID:   GKENamespaceStr,
-		podID:         GKEPodIDStr,
+	autoDetected := GKEContainer{
+		InstanceID:    GCPInstanceIDStr,
+		ProjectID:     GCPProjectIDStr,
+		Zone:          GCPZoneStr,
+		ClusterName:   GKEClusterNameStr,
+		ContainerName: GKEContainerNameStr,
+		NamespaceID:   GKENamespaceStr,
+		PodID:         GKEPodIDStr,
 	}
-	autoDetected := detectResourceType(nil, &gcpMetadata)
 
-	if autoDetected == nil {
-		t.Fatal("GKEContainerMonitoredResource nil")
-	}
 	resType, labels := autoDetected.MonitoredResource()
 	if resType != "gke_container" ||
 		labels["instance_id"] != GCPInstanceIDStr ||
@@ -60,21 +56,17 @@ func TestGKEContainerMonitoredResources(t *testing.T) {
 
 func TestGKEContainerMonitoredResourcesV2(t *testing.T) {
 	os.Setenv("KUBERNETES_SERVICE_HOST", "127.0.0.1")
-	gcpMetadata := gcpMetadata{
-		instanceID:    GCPInstanceIDStr,
-		projectID:     GCPProjectIDStr,
-		zone:          GCPZoneStr,
-		clusterName:   GKEClusterNameStr,
-		containerName: GKEContainerNameStr,
-		namespaceID:   GKENamespaceStr,
-		podID:         GKEPodIDStr,
-		monitoringV2:  true,
+	autoDetected := GKEContainer{
+		InstanceID:                 GCPInstanceIDStr,
+		ProjectID:                  GCPProjectIDStr,
+		Zone:                       GCPZoneStr,
+		ClusterName:                GKEClusterNameStr,
+		ContainerName:              GKEContainerNameStr,
+		NamespaceID:                GKENamespaceStr,
+		PodID:                      GKEPodIDStr,
+		LoggingMonitoringV2Enabled: true,
 	}
-	autoDetected := detectResourceType(nil, &gcpMetadata)
 
-	if autoDetected == nil {
-		t.Fatal("GKEContainerMonitoredResource nil")
-	}
 	resType, labels := autoDetected.MonitoredResource()
 	if resType != "k8s_container" ||
 		labels["project_id"] != GCPProjectIDStr ||
@@ -89,16 +81,12 @@ func TestGKEContainerMonitoredResourcesV2(t *testing.T) {
 
 func TestGCEInstanceMonitoredResources(t *testing.T) {
 	os.Setenv("KUBERNETES_SERVICE_HOST", "")
-	gcpMetadata := gcpMetadata{
-		instanceID: GCPInstanceIDStr,
-		projectID:  GCPProjectIDStr,
-		zone:       GCPZoneStr,
+	autoDetected := GCEInstance{
+		InstanceID: GCPInstanceIDStr,
+		ProjectID:  GCPProjectIDStr,
+		Zone:       GCPZoneStr,
 	}
-	autoDetected := detectResourceType(nil, &gcpMetadata)
 
-	if autoDetected == nil {
-		t.Fatal("GCEInstanceMonitoredResource nil")
-	}
 	resType, labels := autoDetected.MonitoredResource()
 	if resType != "gce_instance" ||
 		labels["instance_id"] != GCPInstanceIDStr ||
@@ -109,19 +97,12 @@ func TestGCEInstanceMonitoredResources(t *testing.T) {
 }
 
 func TestAWSEC2InstanceMonitoredResources(t *testing.T) {
-	os.Setenv("KUBERNETES_SERVICE_HOST", "")
-	gcpMetadata := gcpMetadata{}
-
-	awsIdentityDoc := &awsIdentityDocument{
-		"123456789012",
-		"i-1234567890abcdef0",
-		"us-west-2",
+	autoDetected := AWSEC2Instance{
+		AWSAccount: "123456789012",
+		InstanceID: "i-1234567890abcdef0",
+		Region:     "aws:us-west-2",
 	}
-	autoDetected := detectResourceType(awsIdentityDoc, &gcpMetadata)
 
-	if autoDetected == nil {
-		t.Fatal("AWSEC2InstanceMonitoredResource nil")
-	}
 	resType, labels := autoDetected.MonitoredResource()
 	if resType != "aws_ec2_instance" ||
 		labels["instance_id"] != "i-1234567890abcdef0" ||

--- a/monitoredresource/gcp/gcp_metadata_config.go
+++ b/monitoredresource/gcp/gcp_metadata_config.go
@@ -1,4 +1,4 @@
-// Copyright 2018, OpenCensus Authors
+// Copyright 2020, OpenCensus Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package monitoredresource
+package gcp
 
 import (
 	"context"

--- a/monitoredresource/gcp/monitored_resources.go
+++ b/monitoredresource/gcp/monitored_resources.go
@@ -1,0 +1,168 @@
+// Copyright 2020, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcp
+
+import (
+	"os"
+	"sync"
+)
+
+// Interface is a type that represent monitor resource that satisfies monitoredresource.Interface
+type Interface interface {
+
+	// MonitoredResource returns the resource type and resource labels.
+	MonitoredResource() (resType string, labels map[string]string)
+}
+
+// GKEContainer represents gke_container type monitored resource.
+// For definition refer to
+// https://cloud.google.com/monitoring/api/resources#tag_gke_container
+type GKEContainer struct {
+
+	// ProjectID is the identifier of the GCP project associated with this resource, such as "my-project".
+	ProjectID string
+
+	// InstanceID is the numeric VM instance identifier assigned by Compute Engine.
+	InstanceID string
+
+	// ClusterName is the name for the cluster the container is running in.
+	ClusterName string
+
+	// ContainerName is the name of the container.
+	ContainerName string
+
+	// NamespaceID is the identifier for the cluster namespace the container is running in
+	NamespaceID string
+
+	// PodID is the identifier for the pod the container is running in.
+	PodID string
+
+	// Zone is the Compute Engine zone in which the VM is running.
+	Zone string
+
+	// LoggingMonitoringV2Enabled is the identifier if user enabled V2 logging and monitoring for GKE
+	LoggingMonitoringV2Enabled bool
+}
+
+// MonitoredResource returns resource type and resource labels for GKEContainer
+func (gke *GKEContainer) MonitoredResource() (resType string, labels map[string]string) {
+	labels = map[string]string{
+		"project_id":     gke.ProjectID,
+		"cluster_name":   gke.ClusterName,
+		"container_name": gke.ContainerName,
+	}
+	var typ string
+	if gke.LoggingMonitoringV2Enabled {
+		typ = "k8s_container"
+		labels["pod_name"] = gke.PodID
+		labels["namespace_name"] = gke.NamespaceID
+		labels["location"] = gke.Zone
+	} else {
+		typ = "gke_container"
+		labels["pod_id"] = gke.PodID
+		labels["namespace_id"] = gke.NamespaceID
+		labels["zone"] = gke.Zone
+		labels["instance_id"] = gke.InstanceID
+	}
+	return typ, labels
+}
+
+// GCEInstance represents gce_instance type monitored resource.
+// For definition refer to
+// https://cloud.google.com/monitoring/api/resources#tag_gce_instance
+type GCEInstance struct {
+
+	// ProjectID is the identifier of the GCP project associated with this resource, such as "my-project".
+	ProjectID string
+
+	// InstanceID is the numeric VM instance identifier assigned by Compute Engine.
+	InstanceID string
+
+	// Zone is the Compute Engine zone in which the VM is running.
+	Zone string
+}
+
+// MonitoredResource returns resource type and resource labels for GCEInstance
+func (gce *GCEInstance) MonitoredResource() (resType string, labels map[string]string) {
+	labels = map[string]string{
+		"project_id":  gce.ProjectID,
+		"instance_id": gce.InstanceID,
+		"zone":        gce.Zone,
+	}
+	return "gce_instance", labels
+}
+
+// Autodetect auto detects monitored resources based on
+// the environment where the application is running.
+// It supports detection of following resource types
+// 1. gke_container:
+// 2. gce_instance:
+//
+// Returns MonitoredResInterface which implements getLabels() and getType()
+// For resource definition go to https://cloud.google.com/monitoring/api/resources
+func Autodetect() Interface {
+	return func() Interface {
+		detectOnce.Do(func() {
+			autoDetected = detectResourceType(retrieveGCPMetadata())
+		})
+		return autoDetected
+	}()
+
+}
+
+// createGCEInstanceMonitoredResource creates a gce_instance monitored resource
+// gcpMetadata contains GCP (GKE or GCE) specific attributes.
+func createGCEInstanceMonitoredResource(gcpMetadata *gcpMetadata) *GCEInstance {
+	gceInstance := GCEInstance{
+		ProjectID:  gcpMetadata.projectID,
+		InstanceID: gcpMetadata.instanceID,
+		Zone:       gcpMetadata.zone,
+	}
+	return &gceInstance
+}
+
+// createGKEContainerMonitoredResource creates a gke_container monitored resource
+// gcpMetadata contains GCP (GKE or GCE) specific attributes.
+func createGKEContainerMonitoredResource(gcpMetadata *gcpMetadata) *GKEContainer {
+	gkeContainer := GKEContainer{
+		ProjectID:                  gcpMetadata.projectID,
+		InstanceID:                 gcpMetadata.instanceID,
+		Zone:                       gcpMetadata.zone,
+		ContainerName:              gcpMetadata.containerName,
+		ClusterName:                gcpMetadata.clusterName,
+		NamespaceID:                gcpMetadata.namespaceID,
+		PodID:                      gcpMetadata.podID,
+		LoggingMonitoringV2Enabled: gcpMetadata.monitoringV2,
+	}
+	return &gkeContainer
+}
+
+// detectOnce is used to make sure GCP metadata detect function executes only once.
+var detectOnce sync.Once
+
+// autoDetected is the metadata detected after the first execution of Autodetect function.
+var autoDetected Interface
+
+// detectResourceType determines the resource type.
+// gcpMetadata contains GCP (GKE or GCE) specific attributes.
+func detectResourceType(gcpMetadata *gcpMetadata) Interface {
+	if os.Getenv("KUBERNETES_SERVICE_HOST") != "" &&
+		gcpMetadata != nil && gcpMetadata.instanceID != "" {
+		return createGKEContainerMonitoredResource(gcpMetadata)
+	} else if gcpMetadata != nil && gcpMetadata.instanceID != "" {
+		return createGCEInstanceMonitoredResource(gcpMetadata)
+	}
+	return nil
+}

--- a/monitoredresource/gcp/monitored_resources_test.go
+++ b/monitoredresource/gcp/monitored_resources_test.go
@@ -1,0 +1,109 @@
+// Copyright 2020, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcp
+
+import (
+	"os"
+	"testing"
+)
+
+const (
+	GCPProjectIDStr     = "gcp-project"
+	GCPInstanceIDStr    = "instance"
+	GCPZoneStr          = "us-east1"
+	GKENamespaceStr     = "namespace"
+	GKEPodIDStr         = "pod-id"
+	GKEContainerNameStr = "container"
+	GKEClusterNameStr   = "cluster"
+)
+
+func TestGKEContainerMonitoredResources(t *testing.T) {
+	os.Setenv("KUBERNETES_SERVICE_HOST", "127.0.0.1")
+	gcpMetadata := gcpMetadata{
+		instanceID:    GCPInstanceIDStr,
+		projectID:     GCPProjectIDStr,
+		zone:          GCPZoneStr,
+		clusterName:   GKEClusterNameStr,
+		containerName: GKEContainerNameStr,
+		namespaceID:   GKENamespaceStr,
+		podID:         GKEPodIDStr,
+	}
+	autoDetected := detectResourceType(&gcpMetadata)
+
+	if autoDetected == nil {
+		t.Fatal("GKEContainerMonitoredResource nil")
+	}
+	resType, labels := autoDetected.MonitoredResource()
+	if resType != "gke_container" ||
+		labels["instance_id"] != GCPInstanceIDStr ||
+		labels["project_id"] != GCPProjectIDStr ||
+		labels["cluster_name"] != GKEClusterNameStr ||
+		labels["container_name"] != GKEContainerNameStr ||
+		labels["zone"] != GCPZoneStr ||
+		labels["namespace_id"] != GKENamespaceStr ||
+		labels["pod_id"] != GKEPodIDStr {
+		t.Errorf("GKEContainerMonitoredResource Failed: %v", autoDetected)
+	}
+}
+
+func TestGKEContainerMonitoredResourcesV2(t *testing.T) {
+	os.Setenv("KUBERNETES_SERVICE_HOST", "127.0.0.1")
+	gcpMetadata := gcpMetadata{
+		instanceID:    GCPInstanceIDStr,
+		projectID:     GCPProjectIDStr,
+		zone:          GCPZoneStr,
+		clusterName:   GKEClusterNameStr,
+		containerName: GKEContainerNameStr,
+		namespaceID:   GKENamespaceStr,
+		podID:         GKEPodIDStr,
+		monitoringV2:  true,
+	}
+	autoDetected := detectResourceType(&gcpMetadata)
+
+	if autoDetected == nil {
+		t.Fatal("GKEContainerMonitoredResource nil")
+	}
+	resType, labels := autoDetected.MonitoredResource()
+	if resType != "k8s_container" ||
+		labels["project_id"] != GCPProjectIDStr ||
+		labels["cluster_name"] != GKEClusterNameStr ||
+		labels["container_name"] != GKEContainerNameStr ||
+		labels["location"] != GCPZoneStr ||
+		labels["namespace_name"] != GKENamespaceStr ||
+		labels["pod_name"] != GKEPodIDStr {
+		t.Errorf("GKEContainerMonitoredResourceV2 Failed: %v", autoDetected)
+	}
+}
+
+func TestGCEInstanceMonitoredResources(t *testing.T) {
+	os.Setenv("KUBERNETES_SERVICE_HOST", "")
+	gcpMetadata := gcpMetadata{
+		instanceID: GCPInstanceIDStr,
+		projectID:  GCPProjectIDStr,
+		zone:       GCPZoneStr,
+	}
+	autoDetected := detectResourceType(&gcpMetadata)
+
+	if autoDetected == nil {
+		t.Fatal("GCEInstanceMonitoredResource nil")
+	}
+	resType, labels := autoDetected.MonitoredResource()
+	if resType != "gce_instance" ||
+		labels["instance_id"] != GCPInstanceIDStr ||
+		labels["project_id"] != GCPProjectIDStr ||
+		labels["zone"] != GCPZoneStr {
+		t.Errorf("GCEInstanceMonitoredResource Failed: %v", autoDetected)
+	}
+}

--- a/monitoredresource/monitored_resources.go
+++ b/monitoredresource/monitored_resources.go
@@ -1,4 +1,4 @@
-// Copyright 2018, OpenCensus Authors
+// Copyright 2020, OpenCensus Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,121 +15,16 @@
 package monitoredresource
 
 import (
-	"fmt"
-	"os"
 	"sync"
+
+	"contrib.go.opencensus.io/exporter/stackdriver/monitoredresource/aws"
+	"contrib.go.opencensus.io/exporter/stackdriver/monitoredresource/gcp"
 )
 
 // Interface is a type that represent monitor resource that satisfies monitoredresource.Interface
 type Interface interface {
-
 	// MonitoredResource returns the resource type and resource labels.
 	MonitoredResource() (resType string, labels map[string]string)
-}
-
-// GKEContainer represents gke_container type monitored resource.
-// For definition refer to
-// https://cloud.google.com/monitoring/api/resources#tag_gke_container
-type GKEContainer struct {
-
-	// ProjectID is the identifier of the GCP project associated with this resource, such as "my-project".
-	ProjectID string
-
-	// InstanceID is the numeric VM instance identifier assigned by Compute Engine.
-	InstanceID string
-
-	// ClusterName is the name for the cluster the container is running in.
-	ClusterName string
-
-	// ContainerName is the name of the container.
-	ContainerName string
-
-	// NamespaceID is the identifier for the cluster namespace the container is running in
-	NamespaceID string
-
-	// PodID is the identifier for the pod the container is running in.
-	PodID string
-
-	// Zone is the Compute Engine zone in which the VM is running.
-	Zone string
-
-	// LoggingMonitoringV2Enabled is the identifier if user enabled V2 logging and monitoring for GKE
-	LoggingMonitoringV2Enabled bool
-}
-
-// MonitoredResource returns resource type and resource labels for GKEContainer
-func (gke *GKEContainer) MonitoredResource() (resType string, labels map[string]string) {
-	labels = map[string]string{
-		"project_id":     gke.ProjectID,
-		"cluster_name":   gke.ClusterName,
-		"container_name": gke.ContainerName,
-	}
-	var typ string
-	if gke.LoggingMonitoringV2Enabled {
-		typ = "k8s_container"
-		labels["pod_name"] = gke.PodID
-		labels["namespace_name"] = gke.NamespaceID
-		labels["location"] = gke.Zone
-	} else {
-		typ = "gke_container"
-		labels["pod_id"] = gke.PodID
-		labels["namespace_id"] = gke.NamespaceID
-		labels["zone"] = gke.Zone
-		labels["instance_id"] = gke.InstanceID
-	}
-	return typ, labels
-}
-
-// GCEInstance represents gce_instance type monitored resource.
-// For definition refer to
-// https://cloud.google.com/monitoring/api/resources#tag_gce_instance
-type GCEInstance struct {
-
-	// ProjectID is the identifier of the GCP project associated with this resource, such as "my-project".
-	ProjectID string
-
-	// InstanceID is the numeric VM instance identifier assigned by Compute Engine.
-	InstanceID string
-
-	// Zone is the Compute Engine zone in which the VM is running.
-	Zone string
-}
-
-// MonitoredResource returns resource type and resource labels for GCEInstance
-func (gce *GCEInstance) MonitoredResource() (resType string, labels map[string]string) {
-	labels = map[string]string{
-		"project_id":  gce.ProjectID,
-		"instance_id": gce.InstanceID,
-		"zone":        gce.Zone,
-	}
-	return "gce_instance", labels
-}
-
-// AWSEC2Instance represents aws_ec2_instance type monitored resource.
-// For definition refer to
-// https://cloud.google.com/monitoring/api/resources#tag_aws_ec2_instance
-type AWSEC2Instance struct {
-
-	// AWSAccount is the AWS account number for the VM.
-	AWSAccount string
-
-	// InstanceID is the instance id of the instance.
-	InstanceID string
-
-	// Region is the AWS region for the VM. The format of this field is "aws:{region}",
-	// where supported values for {region} are listed at
-	// http://docs.aws.amazon.com/general/latest/gr/rande.html.
-	Region string
-}
-
-// MonitoredResource returns resource type and resource labels for AWSEC2Instance
-func (aws *AWSEC2Instance) MonitoredResource() (resType string, labels map[string]string) {
-	labels = map[string]string{
-		"aws_account": aws.AWSAccount,
-		"instance_id": aws.InstanceID,
-		"region":      aws.Region,
-	}
-	return "aws_ec2_instance", labels
 }
 
 // Autodetect auto detects monitored resources based on
@@ -144,9 +39,7 @@ func (aws *AWSEC2Instance) MonitoredResource() (resType string, labels map[strin
 func Autodetect() Interface {
 	return func() Interface {
 		detectOnce.Do(func() {
-			var awsIdentityDoc *awsIdentityDocument
-			var gcpMetadata *gcpMetadata
-
+			var awsDetect, gcpDetect Interface
 			// First attempts to retrieve AWS Identity Doc and GCP metadata.
 			// It then determines the resource type
 			// In GCP and AWS environment both func finishes quickly. However,
@@ -157,57 +50,21 @@ func Autodetect() Interface {
 
 			go func() {
 				defer wg.Done()
-				awsIdentityDoc = retrieveAWSIdentityDocument()
+				awsDetect = aws.Autodetect()
 			}()
 			go func() {
 				defer wg.Done()
-				gcpMetadata = retrieveGCPMetadata()
+				gcpDetect = gcp.Autodetect()
 			}()
 
 			wg.Wait()
-			autoDetected = detectResourceType(awsIdentityDoc, gcpMetadata)
+			autoDetected = awsDetect
+			if gcpDetect != nil {
+				autoDetected = gcpDetect
+			}
 		})
 		return autoDetected
 	}()
-
-}
-
-// createAWSEC2InstanceMonitoredResource creates a aws_ec2_instance monitored resource
-// awsIdentityDoc contains AWS EC2 specific attributes.
-func createAWSEC2InstanceMonitoredResource(awsIdentityDoc *awsIdentityDocument) *AWSEC2Instance {
-	awsInstance := AWSEC2Instance{
-		AWSAccount: awsIdentityDoc.accountID,
-		InstanceID: awsIdentityDoc.instanceID,
-		Region:     fmt.Sprintf("aws:%s", awsIdentityDoc.region),
-	}
-	return &awsInstance
-}
-
-// createGCEInstanceMonitoredResource creates a gce_instance monitored resource
-// gcpMetadata contains GCP (GKE or GCE) specific attributes.
-func createGCEInstanceMonitoredResource(gcpMetadata *gcpMetadata) *GCEInstance {
-	gceInstance := GCEInstance{
-		ProjectID:  gcpMetadata.projectID,
-		InstanceID: gcpMetadata.instanceID,
-		Zone:       gcpMetadata.zone,
-	}
-	return &gceInstance
-}
-
-// createGKEContainerMonitoredResource creates a gke_container monitored resource
-// gcpMetadata contains GCP (GKE or GCE) specific attributes.
-func createGKEContainerMonitoredResource(gcpMetadata *gcpMetadata) *GKEContainer {
-	gkeContainer := GKEContainer{
-		ProjectID:                  gcpMetadata.projectID,
-		InstanceID:                 gcpMetadata.instanceID,
-		Zone:                       gcpMetadata.zone,
-		ContainerName:              gcpMetadata.containerName,
-		ClusterName:                gcpMetadata.clusterName,
-		NamespaceID:                gcpMetadata.namespaceID,
-		PodID:                      gcpMetadata.podID,
-		LoggingMonitoringV2Enabled: gcpMetadata.monitoringV2,
-	}
-	return &gkeContainer
 }
 
 // detectOnce is used to make sure GCP and AWS metadata detect function executes only once.
@@ -215,18 +72,3 @@ var detectOnce sync.Once
 
 // autoDetected is the metadata detected after the first execution of Autodetect function.
 var autoDetected Interface
-
-// detectResourceType determines the resource type.
-// awsIdentityDoc contains AWS EC2 attributes. nil if it is not AWS EC2 environment
-// gcpMetadata contains GCP (GKE or GCE) specific attributes.
-func detectResourceType(awsIdentityDoc *awsIdentityDocument, gcpMetadata *gcpMetadata) Interface {
-	if os.Getenv("KUBERNETES_SERVICE_HOST") != "" &&
-		gcpMetadata != nil && gcpMetadata.instanceID != "" {
-		return createGKEContainerMonitoredResource(gcpMetadata)
-	} else if gcpMetadata != nil && gcpMetadata.instanceID != "" {
-		return createGCEInstanceMonitoredResource(gcpMetadata)
-	} else if awsIdentityDoc != nil {
-		return createAWSEC2InstanceMonitoredResource(awsIdentityDoc)
-	}
-	return nil
-}

--- a/resource.go
+++ b/resource.go
@@ -1,4 +1,4 @@
-// Copyright 2019, OpenCensus Authors
+// Copyright 2020, OpenCensus Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,7 +16,9 @@ package stackdriver // import "contrib.go.opencensus.io/exporter/stackdriver"
 
 import (
 	"fmt"
+	"sync"
 
+	"contrib.go.opencensus.io/exporter/stackdriver/monitoredresource/gcp"
 	"go.opencensus.io/resource"
 	"go.opencensus.io/resource/resourcekeys"
 	monitoredrespb "google.golang.org/genproto/googleapis/api/monitoredres"
@@ -27,12 +29,40 @@ import (
 // for customization.
 const (
 	stackdriverProjectID            = "contrib.opencensus.io/exporter/stackdriver/project_id"
+	stackdriverLocation             = "contrib.opencensus.io/exporter/stackdriver/location"
+	stackdriverClusterName          = "contrib.opencesus.io/exporter/stackdriver/cluster_name"
 	stackdriverGenericTaskNamespace = "contrib.opencensus.io/exporter/stackdriver/generic_task/namespace"
 	stackdriverGenericTaskJob       = "contrib.opencensus.io/exporter/stackdriver/generic_task/job"
 	stackdriverGenericTaskID        = "contrib.opencensus.io/exporter/stackdriver/generic_task/task_id"
+
+	knativeResType           = "knative_revision"
+	knativeServiceName       = "service_name"
+	knativeRevisionName      = "revision_name"
+	knativeConfigurationName = "configuration_name"
+	knativeNamespaceName     = "namespace_name"
 )
 
-// Mappings for the well-known OpenCensus resources to applicable Stackdriver resources.
+var (
+	// autodetectFunc returns a monitored resource that is autodetected.
+	// from the cloud environment at runtime.
+	autodetectFunc func() gcp.Interface
+
+	// autodetectOnce is used to lazy initialize autodetectedLabels.
+	autodetectOnce *sync.Once
+	// autodetectedLabels stores all the labels from the autodetected monitored resource
+	// with a possible additional label for the GCP "location".
+	autodetectedLabels map[string]string
+)
+
+func init() {
+	autodetectFunc = gcp.Autodetect
+	// monitoredresource.Autodetect only makes calls to the metadata APIs once
+	// and caches the results
+	autodetectOnce = new(sync.Once)
+}
+
+// Mappings for the well-known OpenCensus resource label keys
+// to applicable Stackdriver Monitored Resource label keys.
 var k8sContainerMap = map[string]string{
 	"project_id":     stackdriverProjectID,
 	"location":       resourcekeys.CloudKeyZone,
@@ -79,16 +109,58 @@ var genericResourceMap = map[string]string{
 	"task_id":    stackdriverGenericTaskID,
 }
 
+var knativeRevisionResourceMap = map[string]string{
+	"project_id":             stackdriverProjectID,
+	"location":               resourcekeys.CloudKeyZone,
+	"cluster_name":           resourcekeys.K8SKeyClusterName,
+	knativeServiceName:       knativeServiceName,
+	knativeRevisionName:      knativeRevisionName,
+	knativeConfigurationName: knativeConfigurationName,
+	knativeNamespaceName:     knativeNamespaceName,
+}
+
+// getAutodetectedLabels returns all the labels from the Monitored Resource detected
+// from the environment by calling monitoredresource.Autodetect. If a "zone" label is detected,
+// a "location" label is added with the same value to account for differences between
+// Legacy Stackdriver and Stackdriver Kubernetes Engine Monitoring,
+// see https://cloud.google.com/monitoring/kubernetes-engine/migration.
+func getAutodetectedLabels() map[string]string {
+	autodetectOnce.Do(func() {
+		autodetectedLabels = map[string]string{}
+		if mr := autodetectFunc(); mr != nil {
+			_, labels := mr.MonitoredResource()
+			// accept "zone" value for "location" because values for location can be a zone
+			// or region, see https://cloud.google.com/docs/geography-and-regions
+			if _, ok := labels["zone"]; ok {
+				labels["location"] = labels["zone"]
+			}
+
+			autodetectedLabels = labels
+		}
+	})
+
+	return autodetectedLabels
+}
+
 // returns transformed label map and true if all labels in match are found
 // in input except optional project_id. It returns false if at least one label
 // other than project_id is missing.
 func transformResource(match, input map[string]string) (map[string]string, bool) {
 	output := make(map[string]string, len(input))
 	for dst, src := range match {
-		v, ok := input[src]
-		if ok {
+		if v, ok := input[src]; ok {
 			output[dst] = v
-		} else if dst != "project_id" {
+			continue
+		}
+
+		// attempt to autodetect missing labels, autodetected label keys should
+		// match destination label keys
+		if v, ok := getAutodetectedLabels()[dst]; ok {
+			output[dst] = v
+			continue
+		}
+
+		if dst != "project_id" {
 			return nil, true
 		}
 	}
@@ -120,6 +192,9 @@ func defaultMapResource(res *resource.Resource) *monitoredrespb.MonitoredResourc
 	case res.Labels[resourcekeys.CloudKeyProvider] == resourcekeys.CloudProviderAWS:
 		result.Type = "aws_ec2_instance"
 		match = awsResourceMap
+	case res.Type == knativeResType:
+		result.Type = res.Type
+		match = knativeRevisionResourceMap
 	}
 
 	var missing bool

--- a/stackdriver_test.go
+++ b/stackdriver_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018, OpenCensus Authors
+// Copyright 2020, OpenCensus Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,11 +24,24 @@ import (
 	"time"
 
 	"contrib.go.opencensus.io/exporter/stackdriver/internal/testpb"
+	"contrib.go.opencensus.io/exporter/stackdriver/monitoredresource/gcp"
 	"go.opencensus.io/plugin/ochttp"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/trace"
 	"golang.org/x/net/context/ctxhttp"
 )
+
+var (
+	dummyAutodetect = func() gcp.Interface {
+		return nil
+	}
+)
+
+func init() {
+	// monitoredresource.Autodetect() takes a few seconds to return when
+	// run outside of a cloud environment, so use a dummy autodetect for tests
+	autodetectFunc = dummyAutodetect
+}
 
 func TestExport(t *testing.T) {
 	projectID, ok := os.LookupEnv("STACKDRIVER_TEST_PROJECT_ID")


### PR DESCRIPTION
* Add default mapping for knative_revision Monitored Resource and
autodetect as many labels as possible metadata

* Split monitoredresource package into monitoredresource/gcp and
monitoredresource/aws

Only detect gcp labels.

* Use golang deprecation notice format